### PR TITLE
Zt crafting section

### DIFF
--- a/src/scripts/CraftForm.js
+++ b/src/scripts/CraftForm.js
@@ -1,11 +1,13 @@
 import { CraftRequests } from "./CraftRequests.js"
 import { Crafters } from "./Crafters.js"
+import { FinishButton } from "./FinishButton.js"
 import { Ingredients } from "./Ingredients.js"
 
 export const CraftForm = async () => {
     const craftRequestsHTML = await CraftRequests()
     const craftersHTML = await Crafters()
     const ingredientsHTML = await Ingredients()
+    const finishButtonHTML = await FinishButton()
 
     let formHTML = `
     <div class="row flex">
@@ -23,6 +25,7 @@ export const CraftForm = async () => {
             </section>
         </div>
     </div>
+    ${finishButtonHTML}
     `
 
     return formHTML

--- a/src/scripts/CraftForm.js
+++ b/src/scripts/CraftForm.js
@@ -1,0 +1,29 @@
+import { CraftRequests } from "./CraftRequests.js"
+import { Crafters } from "./Crafters.js"
+import { Ingredients } from "./Ingredients.js"
+
+export const CraftForm = async () => {
+    const craftRequestsHTML = await CraftRequests()
+    const craftersHTML = await Crafters()
+    const ingredientsHTML = await Ingredients()
+
+    let formHTML = `
+    <div class="row flex">
+        <div class="column flex">
+            <section class="section">
+                ${craftRequestsHTML}
+            </section>
+            <section class="section">
+                ${craftersHTML}
+            </section>
+        </div>
+        <div class="column">
+            <section class="section">
+                ${ingredientsHTML}
+            </section>
+        </div>
+    </div>
+    `
+
+    return formHTML
+}

--- a/src/scripts/CraftRequests.js
+++ b/src/scripts/CraftRequests.js
@@ -25,9 +25,9 @@ const filterCraftRequests = (craftRequestsArray, completionsArray) => {
 
 // Generates the HTML for the dropdown list of Crafting Requests
 const generateDropdownHTML = (craftRequestsArray) => {
-  let craftRequestsHTML = `<div id="craftRequests"><h2 class="section--header">Craft Requests</h2>`
+  let craftRequestsHTML = `<h3>Craft Requests</h3>`
 
-  craftRequestsHTML += `<select class="dropdown" id="craftRequestList">`
+  craftRequestsHTML += `<select id="craftRequestList">`
 
   craftRequestsHTML += `<option value="0" selected disabled hidden>--Choose A Request--</option>`
 
@@ -35,7 +35,7 @@ const generateDropdownHTML = (craftRequestsArray) => {
 
   craftRequestsHTML += optionStringArray.join()
 
-  craftRequestsHTML += `</select></div>`
+  craftRequestsHTML += `</select>`
 
   return craftRequestsHTML
 }

--- a/src/scripts/Crafters.js
+++ b/src/scripts/Crafters.js
@@ -5,7 +5,7 @@
 */
 
 export const Crafters = () => {
-  const crafters = getCrafters();
+  // const crafters = getCrafters();
 
   return `
     <h3>Crafters</h3>

--- a/src/scripts/GnomeMercy.js
+++ b/src/scripts/GnomeMercy.js
@@ -5,11 +5,11 @@
     components.
 */
 
-import { CraftRequests } from "./CraftRequests.js";
 import { Completions } from "./Completions.js"
+import { CraftForm } from "./CraftForm.js";
 
 export const GnomeMercy = async () => {
-  const craftRequestsHTML = await CraftRequests()
+  const CraftFormHTML = await CraftForm()
   const CompletionsHTML = await Completions()
   
   return `
@@ -19,14 +19,7 @@ export const GnomeMercy = async () => {
     </article>
     
     <article id="crafting">
-      <div class="crafting--column">
-        <section class="section">
-          ${craftRequestsHTML}
-        </section>
-      </div>
-      <div class="crafting--column">
-
-      </div>
+      ${CraftFormHTML}
     </article>
     
     <article id="completions">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22,15 +22,16 @@ h1,h2,h3,h4,h5,h6 {
 	display: flex;
 }
 .row {
-	flex-flow: row nowrap
+	flex-flow: row nowrap;
 }
 .column {
-	flex-flow: column nowrap
+	flex-flow: column nowrap;
+	margin: 0 5em;
 }
 .section {
 	margin-left: auto;
 	margin-right: auto;
-	width: 80%;
+	width: auto;
 }
 .dropdown {
 	width: 95%;


### PR DESCRIPTION
### Purpose
To properly render out all sections of the form that deal with crafting a brew

### Files Changed
- Removed direct rendering of Craft Requests and related HTML from `GnomeMercy.js`
- Updated HTML generator to use an h3 tag instead of h2, and removed an unnecessary div in `CraftRequests.js`
- Commented out unfinished code in `Crafters.js`
- Wrote HTML generating function that incorporates all brew crafting elements in the new `CraftForm.js` module
- Updated styling for column and section classes in `main.css`

### To Test
Fetch, serve, and host JSON server
- Confirm Craft Requests and Crafters dropdowns are rendered in a left side column
- Confirm Crafting Ingredients selectors are rendered in a right side column
- Confirm Finish button is rendered below the left side column
- Confirm styling matches documentation